### PR TITLE
Fix compatibility with ES6 Promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
  before_install:
    - npm install -g grunt-cli
    - npm install -g bower
+   - bower install
 
  script:
    - grunt test --browsers Firefox --reporters=dots

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
- language: node_js
- node_js:
-   - "0.10"
+sudo: false
 
- before_install:
-   - npm install -g grunt-cli
-   - npm install -g bower
-   - bower install
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - 4
+  - 5
 
- script:
-   - grunt test --browsers Firefox --reporters=dots
+before_install:
+  - npm install -g grunt-cli
+  - npm install -g bower
+  - bower install
+
+script:
+  - grunt test --browsers Firefox --reporters=dots

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
     "components"
   ],
   "dependencies": {
-    "angular": ">1.2.0"
+    "angular": ">1.2.0",
+    "es6-promise": "~3.1.2"
   },
   "devDependencies": {
     "angular-mocks": ">1.2.0",

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "angular-mocks": ">1.2.0",
-    "jquery": "~2.0.0",
-    "es5-shim": "~2.1.0"
+    "jquery": "~2.2.1",
+    "es5-shim": "~4.5.5"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ module.exports = function (config) {
   config.set({
     frameworks : [ 'jasmine' ],
     files : [
-      'components/jquery/jquery.js',
+      'components/jquery/dist/jquery.js',
       'components/angular/angular.js',
       'components/angular-mocks/angular-mocks.js',
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,9 @@ module.exports = function (config) {
       // The phantomJs does not support bind. Hence we include a shim
       'components/es5-shim/es5-shim.js',
 
+      // ES6 Promise
+      'components/es6-promise/promise.js',
+
       // The library itself
       'src/*.js',
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,13 @@
   "directories": {
     "test": "test"
   },
-  "scripts": {
-    "postinstall": "bower install"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/kirstein/angular-autodisable.git"
   },
   "author": "Mikk Kirstein",
   "license": "MIT",
+  "main": "./src/angular-autodisable.js",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-banner": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
   "license": "MIT",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-banner": "~0.1.4",
-    "grunt-contrib-copy": "^0.6.0",
-    "grunt-contrib-uglify": "^0.6.0",
-    "grunt-karma": "^0.9.0",
-    "karma": "^0.12.23",
+    "grunt-banner": "~0.6.0",
+    "grunt-contrib-copy": "^0.8.2",
+    "grunt-contrib-uglify": "^0.11.1",
+    "grunt-karma": "^0.12.1",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.21",
     "karma-growl-reporter": "~0.1.1",
-    "karma-jasmine": "~0.1.3",
-    "karma-phantomjs-launcher": "^0.1.4"
+    "karma-jasmine": "~0.3.7",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.4"
   },
   "dependencies": {}
 }

--- a/src/angular-autodisable.js
+++ b/src/angular-autodisable.js
@@ -22,15 +22,13 @@
 
     /**
      * Validates if the given promise is really a promise that we can use.
-     * Out promises must have at least `then` and `finally` functions
+     * Out promises must have at least `then` function
      *
      * @param {Object} promise promise to test
      * @return {Boolean} true if its a promise, otherwise false
      */
     function isPromise(promise) {
-      return promise                          &&
-             angular.isFunction(promise.then) &&
-             angular.isFunction(promise['finally']);
+      return promise && angular.isFunction(promise.then);
     }
 
     /**
@@ -130,9 +128,8 @@
         }
         promisesTriggered++;
 
-        promise['finally'](function() {
-          promiseDone();
-        });
+        promise
+          .then(promiseDone, promiseDone);
       };
 
       /**

--- a/test/ng-autodisable-submit.spec.js
+++ b/test/ng-autodisable-submit.spec.js
@@ -26,14 +26,14 @@ describe('angular autodisable', function() {
     it('should throw if no ng-submit is defined', function() {
       expect(function() {
         compile('<form ng-autodisable> <button type="submit"></button> </form>');
-      }).toThrow('ngAutodisable requires ngClick or ngSubmit attribute in order to work');
+      }).toThrowError('ngAutodisable requires ngClick or ngSubmit attribute in order to work');
     });
 
     it('should only call the handler once', function() {
       $rootScope.clickHandler = jasmine.createSpy();
       var el = compile('<form ng-submit="clickHandler()" ng-autodisable> <button type="submit"></button> </form>');
       el.find('button[type=submit]').click();
-      expect($rootScope.clickHandler.callCount).toBe(1);
+      expect($rootScope.clickHandler.calls.count()).toBe(1);
     });
 
     it('should handle more than one directive type', inject(function($q) {

--- a/test/ng-autodisable.spec.js
+++ b/test/ng-autodisable.spec.js
@@ -2,6 +2,8 @@
 describe('angular autodisable', function() {
   'use strict';
 
+  var Promise = window.Promise || ES6Promise.Promise;
+
   it('should pass', function() {
     expect(true).toBe(true);
     expect(false).toBe(!true);
@@ -254,6 +256,53 @@ describe('angular autodisable', function() {
         var el = compile('<button ng-click="clickHandler()" ng-autodisable></button>');
         el.click();
         expect(el.attr('disabled')).not.toBeDefined();
+      });
+    });
+
+    describe('ES6 promise', function() {
+      it('should disable the button if ngClick returns ES6 promise', inject(function($q) {
+        $rootScope.clickHandler = function() {
+          return new Promise(function (resolve, reject) {});
+        };
+        var el = compile('<button ng-click="clickHandler()" ng-autodisable></button>');
+        el.click();
+        expect(el.attr('disabled')).toBeDefined();
+      }));
+
+      it('should remove disabled after the promise is resolved with success', function(done) {
+        var resolve;
+        $rootScope.clickHandler = function() {
+          return new Promise(function (_resolve, reject) {
+            resolve = _resolve
+          });
+        };
+        var el = compile('<button ng-click="clickHandler()" ng-autodisable></button>');
+        el.click();
+        resolve('resolved');
+        $rootScope.$apply();
+        // ES6 promise is async and will be resolved at next tick
+        setTimeout(function () {
+          expect(el.attr('disabled')).not.toBeDefined();
+          done();
+        }, 0)
+      });
+
+      it('should remove disabled after the promise is resolved with error', function(done) {
+        var reject;
+        $rootScope.clickHandler = function() {
+          return new Promise(function (resolve, _reject) {
+            reject = _reject
+          });
+        };
+        var el = compile('<button ng-click="clickHandler()" ng-autodisable></button>');
+        el.click();
+        reject('rejected');
+        $rootScope.$apply();
+        // ES6 promise is async and will be resolved at next tick
+        setTimeout(function () {
+          expect(el.attr('disabled')).not.toBeDefined();
+          done();
+        }, 0)
       });
     });
   });

--- a/test/ng-autodisable.spec.js
+++ b/test/ng-autodisable.spec.js
@@ -26,14 +26,14 @@ describe('angular autodisable', function() {
     it('should throw if no ng-click is defined', function() {
       expect(function() {
         compile('<button ng-autodisable></button>');
-      }).toThrow('ngAutodisable requires ngClick or ngSubmit attribute in order to work');
+      }).toThrowError('ngAutodisable requires ngClick or ngSubmit attribute in order to work');
     });
 
     it('should only call the handler once', function() {
       $rootScope.clickHandler = jasmine.createSpy();
       var el = compile('<button ng-click="clickHandler()" ng-autodisable></button>');
       el.click();
-      expect($rootScope.clickHandler.callCount).toBe(1);
+      expect($rootScope.clickHandler.calls.count()).toBe(1);
     });
 
     it('should trigger $scope.$apply when calling the handler', function() {


### PR DESCRIPTION
`finally` is not yet implemented in ES6 promise.
Modify `isPromise` for only testing `then` method and use `then` method for both `onFulfilled` and `onRejected`.

Links:
- https://esdiscuss.org/topic/proposal-promise-prototype-finally
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
- https://github.com/then/is-promise
##### Also included:

(Can be split into different PR)

> ##### Bump all dependencies to last versions
> - jasmine updated to `2.4.1`:
>   - replace `.callCount` by `calls.count()`
>   - replace `toThrow` by `toThrowError`
> - jQuery updated to `2.2.1`:
>   - change path to `jquery/dist/jquery.js`
> - compatibility with `npm@3`, install peer dependencies:
>   - `jasmine-core` `^2.4.1`
>   - `phantomjs-prebuilt` `^2.1.4`
