### PR TITLE
allow multiple submit buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ If that's done then just follow those simple steps:
 ```
   <form ng-submit="doSomething()" ng-autodisable> 
     ...
-    <button type="submit">Submit</button> 
+    <button type="submit">Submit 1</button> 
+    ...
+    <button type="submit">Submit 2</button> 
   </form>
 ```
-The button with type `submit` within the form will be disabled.
+All buttons with type `submit` within the form will be disabled.
 
 #### Loading class
 

--- a/src/angular-autodisable.js
+++ b/src/angular-autodisable.js
@@ -10,7 +10,7 @@
    *
    * @throws error if the `ngAutodisable` is on the element without the `ngClick` directive.
    */
-  .directive('ngAutodisable', [ '$parse', '$document', function($parse, $document) {
+  .directive('ngAutodisable', [ '$parse', function($parse) {
 
     var DISABLED = 'disabled',      // Disabled attribute
         ATTRNAME = 'ngAutodisable', // The attribute name to which we store the handlers ids
@@ -60,14 +60,17 @@
      */
     function linkFn(scope, element, attrs) {
       var handlers = [];
+      var eventName;
 
       if (attrs.hasOwnProperty(CLICK_ATTR)) {
+          eventName = CLICK_EVENT;
           handlers.push(handlerInstance(element,
               CLICK_EVENT,
               getLoadingClass(attrs),
               getCallbacks(attrs[CLICK_ATTR])));
       } else if (attrs.hasOwnProperty(SUBMIT_ATTR)) {
-          var buttons = $document.find('button');
+          eventName = SUBMIT_EVENT;
+          var buttons = element.find('button');
           if (buttons.length === 0) {
             throw new Error('ngAutodisable on a from requires buttons with \'type="submit"\'');
           }
@@ -85,8 +88,8 @@
 
       // Remove the click handler and replace it with our new one
       // with this move we completely disable the original ngClick functionality
-      angular.forEach(handlers, function (handler) {
-          element.unbind(handler.eventName).bind(handler.eventName, function (event) {
+      element.unbind(eventName).bind(eventName, function (event) {
+          angular.forEach(handlers, function (handler) {
               // Make sure we run the $digest cycle
               scope.$apply(function () {
                   handler.callbacks.forEach(triggerHandler.bind(null, handler, scope, event));

--- a/src/angular-autodisable.js
+++ b/src/angular-autodisable.js
@@ -59,42 +59,39 @@
      * @param {Object} attrs attributes
      */
     function linkFn(scope, element, attrs) {
-      var handlers = [];
-      var eventName;
+      var handler;
 
       if (attrs.hasOwnProperty(CLICK_ATTR)) {
-          eventName = CLICK_EVENT;
-          handlers.push(handlerInstance(element,
-              CLICK_EVENT,
-              getLoadingClass(attrs),
-              getCallbacks(attrs[CLICK_ATTR])));
+        handler= handlerInstance([element],
+            CLICK_EVENT,
+            getLoadingClass(attrs),
+            getCallbacks(attrs[CLICK_ATTR]));
       } else if (attrs.hasOwnProperty(SUBMIT_ATTR)) {
-          eventName = SUBMIT_EVENT;
-          var buttons = element.find('button');
-          if (buttons.length === 0) {
-            throw new Error('ngAutodisable on a from requires buttons with \'type="submit"\'');
+        var buttons = element.find('button');
+        if (buttons.length === 0) {
+          throw new Error('ngAutodisable on a from requires buttons with \'type="submit"\'');
+        }
+        var submitButtons = [];
+        angular.forEach(buttons, function (button) {
+          if (button.type === SUBMIT_EVENT) {
+            submitButtons.push(angular.element(button));
           }
-          angular.forEach(buttons, function (button) {
-              if (button.type === SUBMIT_EVENT) {
-                  handlers.push(handlerInstance(angular.element(button),
-                      SUBMIT_EVENT,
-                      getLoadingClass(attrs),
-                      getCallbacks(attrs[SUBMIT_ATTR])));
-              }
-          });
+        });
+        handler = handlerInstance(submitButtons,
+            SUBMIT_EVENT,
+            getLoadingClass(attrs),
+            getCallbacks(attrs[SUBMIT_ATTR]));
       } else {
-          throw new Error('ngAutodisable requires ngClick or ngSubmit attribute in order to work');
+        throw new Error('ngAutodisable requires ngClick or ngSubmit attribute in order to work');
       }
 
       // Remove the click handler and replace it with our new one
       // with this move we completely disable the original ngClick functionality
-      element.unbind(eventName).bind(eventName, function (event) {
-          angular.forEach(handlers, function (handler) {
-              // Make sure we run the $digest cycle
-              scope.$apply(function () {
-                  handler.callbacks.forEach(triggerHandler.bind(null, handler, scope, event));
-              });
-          });
+      element.unbind(handler.eventName).bind(handler.eventName, function (event) {
+        // Make sure we run the $digest cycle
+        scope.$apply(function () {
+          handler.callbacks.forEach(triggerHandler.bind(null, handler, scope, event));
+        });
       });
     }
 
@@ -114,13 +111,13 @@
      * It will disable the given element when the first promise is triggered. And will
      * re-enable the element, when the last promise is finished.
      *
-     * @param  {Element} elementToDisable     DOM element that should be enabled and disabled.
+     * @param  {Element}[] elementsToDisable  DOM elements that should be enabled and disabled.
      * @param  {String} eventName             Name of the event ('click' or 'submit')
      * @param  {String|Boolean} loadingClass  Class(es) to toggle to the element or false not desired.
      * @param  {Array} callbacks              Array of callback functions to trigger.
      * @return {Object}                       Object that handles the promises.
      */
-    function handlerInstance(elementToDisable, eventName, loadingClass, callbacks) {
+    function handlerInstance(elementsToDisable, eventName, loadingClass, callbacks) {
       var instance = {},
           promisesTriggered = 0;
 
@@ -137,7 +134,7 @@
        */
       instance.handlePromise = function(promise) {
         if (promisesTriggered === 0) {
-          disableElement();
+          disableElements();
         }
         promisesTriggered++;
 
@@ -153,7 +150,7 @@
       function promiseDone() {
         promisesTriggered--;
         if (promisesTriggered === 0) {
-          enableElement();
+          enableElements();
         }
       }
 
@@ -161,22 +158,26 @@
        * Disables the element. It can also add the classes listed by
        * loadingClass.
        */
-      function disableElement() {
-        elementToDisable.attr(DISABLED, true);
-        if (loadingClass) {
-          elementToDisable.addClass(loadingClass);
-        }
+      function disableElements() {
+        angular.forEach(elementsToDisable, function(elementToDisable) {
+          elementToDisable.attr(DISABLED, true);
+          if (loadingClass) {
+            elementToDisable.addClass(loadingClass);
+          }
+        });
       }
 
       /**
        * Enables the element. It can also remove the classes listed by
        * loadingClass.
        */
-      function enableElement() {
-        elementToDisable.attr(DISABLED, false);
-        if (loadingClass) {
-          elementToDisable.removeClass(loadingClass);
-        }
+      function enableElements() {
+        angular.forEach(elementsToDisable, function (elementToDisable) {
+          elementToDisable.attr(DISABLED, false);
+          if (loadingClass) {
+            elementToDisable.removeClass(loadingClass);
+          }
+        });
       }
 
       return instance;


### PR DESCRIPTION
Allows multiple buttons with `type="submit"`.
Fixes `$ is not defined` error with webpack etc. by using `angular.element` and `$document.find`.
